### PR TITLE
Add `Cinder` client class and process user pipeline misconfiguration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+spamostack
+==========
+
+.. image:: https://travis-ci.org/seecloud/spamostack.svg?branch=master
+    :target: https://travis-ci.org/seecloud/spamostack
+.. image:: https://coveralls.io/repos/github/seecloud/spamostack/badge.svg?branch=master
+    :target: https://coveralls.io/github/seecloud/spamostack?branch=master
+
 Installation
 ------------
 
@@ -19,13 +27,6 @@ For installation just type it in the project folder ``pip install -e .``
 
 Configuring spamostack
 ----------------------
-spamostack
-==========
-
-.. image:: https://travis-ci.org/seecloud/spamostack.svg?branch=master
-    :target: https://travis-ci.org/seecloud/spamostack
-.. image:: https://coveralls.io/repos/github/seecloud/spamostack/badge.svg?branch=master
-    :target: https://coveralls.io/github/seecloud/spamostack?branch=master
 
 Please, configure your settings by changing config file in the ``/etc/spamostack`` folder.
 File ``openrc`` is needed for connecting to your cloud, and ``conf.json`` file is needed for configuring pipelines.

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,7 @@
-spamostack
-==========
-
-.. image:: https://travis-ci.org/seecloud/spamostack.svg?branch=master
-    :target: https://travis-ci.org/seecloud/spamostack
-.. image:: https://coveralls.io/repos/github/seecloud/spamostack/badge.svg?branch=master
-    :target: https://coveralls.io/github/seecloud/spamostack?branch=master
-
-
 Installation
 ------------
 
-For installation just use ``pip install -e .``
+For installation just type it in the project folder ``pip install -e .``
 
 +------------------+
 | Working services |
@@ -28,9 +19,16 @@ For installation just use ``pip install -e .``
 
 Configuring spamostack
 ----------------------
+spamostack
+==========
 
-Please, configure your settings by changing config file in etc/ folder.
-File ``openrc`` is needed for connecting to your cloud, and file ``conf.json`` is needed for configuring pipelines
+.. image:: https://travis-ci.org/seecloud/spamostack.svg?branch=master
+    :target: https://travis-ci.org/seecloud/spamostack
+.. image:: https://coveralls.io/repos/github/seecloud/spamostack/badge.svg?branch=master
+    :target: https://coveralls.io/github/seecloud/spamostack?branch=master
+
+Please, configure your settings by changing config file in the ``/etc/spamostack`` folder.
+File ``openrc`` is needed for connecting to your cloud, and ``conf.json`` file is needed for configuring pipelines.
 
 
 Configuring keystone
@@ -51,21 +49,29 @@ Example:
          "users":
          {
           "create": [60, 2, 1],
-          "update": [120, 2, 2]
+          "update": [120, 2, 2],
+          "delete": [30, 1, 1]
          }
        }
      }
    }
 
-That means, that spamostack should:
+That means, that spamostack will:
 
 - Create 1 project in 60 seconds and do it once
 - Update 1 project in 60 seconds and do it once
 - Create 2 users in 60 seconds and do it once
 - Update 2 users in 120 seconds and do it twice
+- Delete 1 user in 30 seconds and do it once
 
 Using spamostack
 ----------------
 
-1. Run ``source /etc/openrc``
-2. Just run it with ``spamostack``. Config file with pipelines will be read from etc/ folder
+1. Run ``source /etc/spamostack/openrc``
+2. Just run it with ``spamostack``. Config file with pipelines will be read from the ``/etc/spamostack/conf.json`` file.
+
+Alternatively you could pass some arguments in the ``argparse`` form:
+
+``spamostack --pipe path/to/pipeline/file --db path/to/database``
+
+And for cleaning that mess use ``spamostack --clean component_name`` for ex: ``spamostack --clean keystone``.

--- a/etc/conf.json
+++ b/etc/conf.json
@@ -5,20 +5,20 @@
     {
       "projects":
       {
-        "create": [60, 1, 1],
-        "update": [60, 1, 1]
+        "create": [30, 1, 1],
+        "update": [30, 1, 1]
       },
       "users":
       {
-        "create": [60, 2, 1],
-        "update": [120, 2, 1]
+        "create": [30, 2, 1],
+        "update": [60, 2, 1]
       }
     },
     "cinder":
     {
       "volumes":
       {
-        "create": [60, 2, 1]
+        "create": [30, 2, 1]
       }
     }
   },
@@ -28,14 +28,24 @@
     {
       "projects":
       {
-        "create": [60, 2, 1],
-        "update": [60, 1, 1],
+        "create": [30, 2, 1],
+        "update": [30, 1, 1],
         "delete": [30, 1, 1]
       },
       "users":
       {
-        "create": [60, 2, 1],
-        "update": [120, 2, 1]
+        "create": [30, 2, 1],
+        "update": [60, 2, 1]
+      }
+    },
+    "cinder":
+    {
+      "volumes":
+      {
+        "create": [30, 2, 1],
+        "update": [30, 1, 1],
+        "attach": [30, 1, 1],
+        "delete": [30, 1, 1]
       }
     }
   }

--- a/etc/conf.json
+++ b/etc/conf.json
@@ -13,6 +13,13 @@
         "create": [60, 2, 1],
         "update": [120, 2, 1]
       }
+    },
+    "cinder":
+    {
+      "volumes":
+      {
+        "create": [60, 2, 1]
+      }
     }
   },
   "pipe2":
@@ -21,7 +28,7 @@
     {
       "projects":
       {
-        "create": [60, 1, 1],
+        "create": [60, 2, 1],
         "update": [60, 1, 1],
         "delete": [30, 1, 1]
       },

--- a/etc/conf.json
+++ b/etc/conf.json
@@ -22,7 +22,8 @@
       "projects":
       {
         "create": [60, 1, 1],
-        "update": [60, 1, 1]
+        "update": [60, 1, 1],
+        "delete": [30, 1, 1]
       },
       "users":
       {

--- a/etc/openrc
+++ b/etc/openrc
@@ -1,6 +1,8 @@
 export OS_USERNAME='admin'
 export OS_PASSWORD='secret'
 export OS_PROJECT_NAME='admin'
+export OS_PROJECT_DOMAIN_ID='default'
+export OS_USER_DOMAIN_ID='default'
 export OS_AUTH_URL='http://192.168.122.218:5000/v3'
 export OS_COMPUTE_API_VERSION='2'
 export OS_IDENTITY_API_VERSION='3'

--- a/spamostack/cache.py
+++ b/spamostack/cache.py
@@ -122,15 +122,15 @@ class Cache(collections.MutableMapping, object):
                       os.environ['OS_PASSWORD'],
                       "os_project_name":
                       os.environ['OS_PROJECT_NAME'],
-                      "os_auth_url":
-                      os.environ['OS_AUTH_URL'],
                       "os_project_domain_id":
                       os.environ['OS_PROJECT_DOMAIN_ID'],
                       "os_user_domain_id":
                       os.environ['OS_USER_DOMAIN_ID']}
         self.cache["users"][uname] = admin_user
 
-        self.cache["api"] = {"os_compute_api_version":
+        self.cache["api"] = {"os_auth_url":
+                             os.environ['OS_AUTH_URL'],
+                             "os_compute_api_version":
                              os.environ['OS_COMPUTE_API_VERSION'],
                              "os_identity_api_version":
                              os.environ['OS_IDENTITY_API_VERSION'],

--- a/spamostack/client_factory.py
+++ b/spamostack/client_factory.py
@@ -238,7 +238,7 @@ class Keystone(object):
             user = self.keeper.get_by_id("keystone", "users", user_id)
             if user.name != "admin":
                 break
-        
+
         self.client.users.delete(user)
         return user_id
 
@@ -278,7 +278,8 @@ class Keystone(object):
     @uncache
     def project_delete(self):
         while True:
-            project_id = self.keeper.get_random(self.cache["keystone"]["projects"])
+            project_id = self.keeper.get_random(
+                self.cache["keystone"]["projects"])
             project = self.keeper.get_by_id("keystone", "projects", project_id)
             if project.name != "admin":
                 break

--- a/spamostack/client_factory.py
+++ b/spamostack/client_factory.py
@@ -46,7 +46,7 @@ def uncache(func):
             section = "users"
         elif "project" in func.__name__:
             section = "projects"
-        del self.cache[self.__class__.__name__.lower()][section][processed.id]
+        del self.cache[self.__class__.__name__.lower()][section][processed]
 
         return processed
 
@@ -59,8 +59,10 @@ class ClientFactory(object):
 
         @param cahce: Reference to the cache
         @type cache: spamostack.cache.Cache
+
         @param user: User for client factory instance
         @type user: `dict` or `User`
+
         @param keeper: Reference to the keeper
         @type keeper: `keeper.Keeper`
         """
@@ -130,10 +132,15 @@ class Keystone(object):
 
         @param cache: Cache
         @type cache: `cache.Cache`
+
+        @param client: An instance of the identity client
+        @type: client: `clientmanager.identity`
+
+        @param faker: An instance of the faker object
+        @type faker: `faker.Factory`
+
         @param keeper: Reference to the keeper
         @type keeper: `keeper.Keeper`
-        @param active_session: Specific session for that client
-        @type active_session: `session.Session`
         """
 
         self.cache = cache
@@ -150,16 +157,21 @@ class Keystone(object):
         self.users.create = self.user_create
         self.users.update = self.user_update
         self.users.delete = self.user_delete
+        self.users.old_delete = self.client.users.delete
 
         self.projects.get = self.client.projects.get
-        self.projects.fidn = self.client.projects.find
+        self.projects.find = self.client.projects.find
         self.projects.create = self.project_create
         self.projects.update = self.project_update
         self.projects.delete = self.project_delete
 
     @cache
     def user_create(self):
-        name = self.faker.name()
+        while True:
+            name = self.faker.name()
+            if self.keeper.get_by_name("keystone", "users", name) is None:
+                break
+
         password = self.faker.password()
         email = self.faker.safe_email()
         project_id = self.keeper.get_random(self.cache["keystone"]["projects"])
@@ -174,21 +186,42 @@ class Keystone(object):
                                         default_project=project)
 
         self.roles.grant(self.roles.find(name="admin"), user, project=project)
-        self.cache["users"][name] = {"password": password,
-                                     "project_name": project.name,
-                                     "project_domain_id": project.domain_id}
+        self.cache["users"][name] = {"os_username": user.name,
+                                     "os_password": password,
+                                     "os_project_name": project.name,
+                                     "os_project_domain_id": project.domain_id,
+                                     "os_user_domain_id": user.domain_id}
 
         return user
 
     @cache
     def user_update(self):
-        name = self.faker.name()
-        password = self.faker.password()
-        email = self.faker.safe_email()
-        user = None
-        while user is None or user.name == "admin":
+        while True:
+            name = self.faker.name()
+            if self.keeper.get_by_name("keystone", "users", name) is None:
+                break
+
+        while True:
             user_id = self.keeper.get_random(self.cache["keystone"]["users"])
             user = self.keeper.get_by_id("keystone", "users", user_id)
+            if user.name != "admin":
+                break
+
+        password = self.faker.password()
+        email = self.faker.safe_email()
+
+        self.cache["users"][name] = {"os_username": name,
+                                     "os_password": password,
+                                     "os_project_name":
+                                     self.cache["users"]
+                                     [user.name]["os_project_name"],
+                                     "os_project_domain_id":
+                                     self.cache["users"]
+                                     [user.name]["os_project_domain_id"],
+                                     "os_user_domain_id":
+                                     self.cache["users"]
+                                     [user.name]["os_user_domain_id"]}
+        del self.cache["users"][user.name]
         return self.client.users.update(user=user,
                                         name=name,
                                         domain="default",
@@ -200,13 +233,22 @@ class Keystone(object):
 
     @uncache
     def user_delete(self):
-        user_id = self.keeper.get_random(self.cache["keystone"]["users"])
-        return self.client.users.delete(
-            self.keeper.get_by_id("keystone", "users", user_id))
+        while True:
+            user_id = self.keeper.get_random(self.cache["keystone"]["users"])
+            user = self.keeper.get_by_id("keystone", "users", user_id)
+            if user.name != "admin":
+                break
+        
+        self.client.users.delete(user)
+        return user_id
 
     @cache
     def project_create(self):
-        name = self.faker.word()
+        while True:
+            name = self.faker.word()
+            if self.keeper.get_by_name("keystone", "projects", name) is None:
+                break
+
         return self.client.projects.create(name=name,
                                            domain="default",
                                            description=("Project {}".
@@ -215,12 +257,17 @@ class Keystone(object):
 
     @cache
     def project_update(self):
-        name = self.faker.word()
-        project = None
-        while project is None or project.name == "admin":
+        while True:
+            name = self.faker.word()
+            if self.keeper.get_by_name("keystone", "projects", name) is None:
+                break
+
+        while True:
             project_id = self.keeper.get_random(
                 self.cache["keystone"]["projects"])
             project = self.keeper.get_by_id("keystone", "projects", project_id)
+            if project.name != "admin":
+                break
         return self.client.projects.update(project=project,
                                            name=name,
                                            domain="default",
@@ -230,9 +277,14 @@ class Keystone(object):
 
     @uncache
     def project_delete(self):
-        project_id = self.keeper.get_random(self.cache["keystone"]["projects"])
-        return self.client.projects.delete(
-            self.keeper.get_by_id("keystone", "projects", project_id))
+        while True:
+            project_id = self.keeper.get_random(self.cache["keystone"]["projects"])
+            project = self.keeper.get_by_id("keystone", "projects", project_id)
+            if project.name != "admin":
+                break
+
+        self.client.projects.delete(project)
+        return project_id
 
 
 class Neutron(object):

--- a/spamostack/keeper.py
+++ b/spamostack/keeper.py
@@ -37,13 +37,22 @@ class Keeper(object):
         client = getattr(self.client_factory, "keystone")()
         user = client.users.find(name="admin")
         project = client.projects.find(name="admin")
-        self.client_factory.nova().native.quotas.update(
-            project.id, cores=-1, floating_ips=-1, gigabytes=-1, instances=-1,
-            key_pairs=-1, networks=-1, ports=-1, properties=-1, ram=-1,
-            rbac_policies=-1, routers=-1, secgroup_rules=-1, secgroups=-1,
-            server_group_members=-1, server_groups=-1, snapshots=-1,
-            subnets=-1, volumes=-1)
         self.cache["keystone"]["users"][user.id] = False
+
+        # quotas update
+        self.client_factory.cinder().native.quotas.update(project.id,
+            backup_gigabytes=-1, backups=-1, gigabytes=-1,
+            per_volume_gigabytes=-1, snapshots=-1, volumes=-1)
+        self.client_factory.neutron().native.update_quota(project.id,
+            subnet=-1, network=-1, floatingip=-1, subnetpool=-1, port=-1,
+            security_group_rule=-1, security_group=-1, router=-1,
+            rbac_policy=-1)
+        self.client_factory.nova().native.quotas.update(project.id,
+            cores=-1, fixed_ips=-1, floating_ips=-1,
+            injected_file_content_bytes=-1, injected_file_path_bytes=-1,
+            injected_files=-1, instances=-1, key_pairs=-1, metadata_items=-1,
+            ram=-1, security_group_rules=-1, security_groups=-1,
+            server_group_members=-1, server_groups=-1)
 
     def get_by_id(self, client_name, resource_name, id):
         """Get resource by id

--- a/spamostack/main.py
+++ b/spamostack/main.py
@@ -17,6 +17,7 @@ import argparse
 import collections
 import json
 import logging
+import sys
 
 from cache import Cache
 from client_factory import ClientFactory
@@ -30,6 +31,8 @@ parser.add_argument('--pipe', dest='pipelines',
                     default='/etc/spamostack/conf.json',
                     help='Path to the config file with pipes')
 parser.add_argument('--db', dest='db', default='./db',
+                    help='Path to the database directory')
+parser.add_argument('--clean', dest='clean', nargs='+',
                     help='Path to the database directory')
 args = parser.parse_args()
 
@@ -49,6 +52,10 @@ def main():
 
     admin_factory = ClientFactory(cache, cache["users"]["admin"])
     admin_keeper = Keeper(cache, admin_factory)
+
+    if args.clean:
+        admin_keeper.clean(args.clean)
+        sys.exit()
 
     for pipe_name, pipe in pipelines.iteritems():
         simulators.append(Simulator(pipe_name, pipe, cache, admin_keeper))

--- a/spamostack/simulator.py
+++ b/spamostack/simulator.py
@@ -33,10 +33,13 @@ class Simulator(object):
 
         @param name: Name of the pipeline
         @type name: `str`
+
         @param pipeline: Pipeline to be executed
         @type pipeline: `dict`
+
         @param cahce: Reference to the cache
         @type cache: `spamostack.cache.Cache`
+
         @param keeper: Reference to the keeper
         @type keeper: `keeper.Keeper`
         """
@@ -73,10 +76,13 @@ class Simulator(object):
 
         @param func: Method to be executed
         @type func: `method`
+
         @param period: Time line to execute the method
         @type period: `int`
+
         @param number: Number of executes
         @type number: `int`
+
         @param count: Number of repeats that period
         @type count: `int`
         """


### PR DESCRIPTION
- keeper.py
  - Change the behaviour of `get_unused` method
  - Add `get_used` method
  - Update quotas of `admin` project in the `default_init`
- client_factory.py
  - Add `Cinder` client class
  - Add processing of pipeline misconfigurations
  - Update quotas in the every new projects
