### PR TITLE
Add `Cinder` client class. Process user pipeline misconfiguration. Update quotas.

### DIFF
--- a/etc/conf.json
+++ b/etc/conf.json
@@ -5,13 +5,20 @@
     {
       "projects":
       {
-        "create": [60, 1, 1],
-        "update": [60, 1, 1]
+        "create": [30, 1, 1],
+        "update": [30, 1, 1]
       },
       "users":
       {
-        "create": [60, 2, 1],
-        "update": [120, 2, 1]
+        "create": [30, 2, 1],
+        "update": [60, 2, 1]
+      }
+    },
+    "cinder":
+    {
+      "volumes":
+      {
+        "create": [30, 2, 1]
       }
     }
   },
@@ -21,14 +28,24 @@
     {
       "projects":
       {
-        "create": [60, 1, 1],
-        "update": [60, 1, 1],
+        "create": [30, 2, 1],
+        "update": [30, 1, 1],
         "delete": [30, 1, 1]
       },
       "users":
       {
-        "create": [60, 2, 1],
-        "update": [120, 2, 1]
+        "create": [30, 2, 1],
+        "update": [60, 2, 1]
+      }
+    },
+    "cinder":
+    {
+      "volumes":
+      {
+        "create": [30, 2, 1],
+        "update": [30, 1, 1],
+        "attach": [30, 1, 1],
+        "delete": [30, 1, 1]
       }
     }
   }

--- a/spamostack/client_factory.py
+++ b/spamostack/client_factory.py
@@ -39,6 +39,7 @@ def cache(func):
 
     return wrapper
 
+
 def uncache(func):
     def wrapper(self, *args, **kwargs):
         processed = func(self, *args, **kwargs)

--- a/spamostack/client_factory.py
+++ b/spamostack/client_factory.py
@@ -14,6 +14,7 @@
 # under the License.
 
 import argparse
+import random
 
 import faker
 from openstackclient.common import clientmanager
@@ -29,13 +30,14 @@ def cache(func):
             section = "users"
         elif "project" in func.__name__:
             section = "projects"
+        elif "volume" in func.__name__:
+            section = "volumes"
         (self.cache[self.__class__.__name__.lower()][section].
          setdefault(processed.id, False))
 
         return processed
 
     return wrapper
-
 
 def uncache(func):
     def wrapper(self, *args, **kwargs):
@@ -144,23 +146,25 @@ class Keystone(object):
         """
 
         self.cache = cache
-        self.client = client
+        self.native = client
         self.faker = faker
         self.keeper = keeper
 
         self.users = lambda: None
         self.projects = lambda: None
-        self.roles = self.client.roles
 
-        self.users.get = self.client.users.get
-        self.users.find = self.client.users.find
+        self.users.get = self.native.users.get
+        self.users.find = self.native.users.find
+        self.users.list = self.native.users.list
+
         self.users.create = self.user_create
         self.users.update = self.user_update
         self.users.delete = self.user_delete
-        self.users.old_delete = self.client.users.delete
 
-        self.projects.get = self.client.projects.get
-        self.projects.find = self.client.projects.find
+        self.projects.get = self.native.projects.get
+        self.projects.find = self.native.projects.find
+        self.projects.list = self.native.projects.list
+
         self.projects.create = self.project_create
         self.projects.update = self.project_update
         self.projects.delete = self.project_delete
@@ -175,8 +179,13 @@ class Keystone(object):
         password = self.faker.password()
         email = self.faker.safe_email()
         project_id = self.keeper.get_random(self.cache["keystone"]["projects"])
+
+        # TO-DO: Make a normal warning logging
+        if project_id is None:
+            return
+
         project = self.keeper.get_by_id("keystone", "projects", project_id)
-        user = self.client.users.create(name=name,
+        user = self.native.users.create(name=name,
                                         domain="default",
                                         password=password,
                                         email=email,
@@ -185,7 +194,8 @@ class Keystone(object):
                                         enabled=True,
                                         default_project=project)
 
-        self.roles.grant(self.roles.find(name="admin"), user, project=project)
+        self.native.roles.grant(self.native.roles.find(name="admin"),
+                                user, project=project)
         self.cache["users"][name] = {"os_username": user.name,
                                      "os_password": password,
                                      "os_project_name": project.name,
@@ -194,9 +204,11 @@ class Keystone(object):
 
         return user
 
-    @cache
     def user_update(self):
         while True:
+            # TO-DO: Make a normal warning logging
+            if len(self.cache["keystone"]["users"]) == 1:
+                return
             name = self.faker.name()
             if self.keeper.get_by_name("keystone", "users", name) is None:
                 break
@@ -222,7 +234,8 @@ class Keystone(object):
                                      self.cache["users"]
                                      [user.name]["os_user_domain_id"]}
         del self.cache["users"][user.name]
-        return self.client.users.update(user=user,
+
+        return self.native.users.update(user=user,
                                         name=name,
                                         domain="default",
                                         password=password,
@@ -234,12 +247,15 @@ class Keystone(object):
     @uncache
     def user_delete(self):
         while True:
+            # TO-DO: Make a normal warning logging
+            if len(self.cache["keystone"]["users"]) == 1:
+                return
             user_id = self.keeper.get_random(self.cache["keystone"]["users"])
             user = self.keeper.get_by_id("keystone", "users", user_id)
             if user.name != "admin":
                 break
 
-        self.client.users.delete(user)
+        self.native.users.delete(user)
         return user_id
 
     @cache
@@ -249,13 +265,28 @@ class Keystone(object):
             if self.keeper.get_by_name("keystone", "projects", name) is None:
                 break
 
-        return self.client.projects.create(name=name,
-                                           domain="default",
-                                           description=("Project {}".
-                                                        format(name)),
-                                           enabled=True)
+        project = self.native.projects.create(name=name,
+                                              domain="default",
+                                              description=("Project {}".
+                                                           format(name)),
+                                              enabled=True)
+        # quotas update
+        self.keeper.client_factory.cinder().native.quotas.update(project.id,
+            backup_gigabytes=-1, backups=-1, gigabytes=-1,
+            per_volume_gigabytes=-1, snapshots=-1, volumes=-1)
+        self.keeper.client_factory.neutron().native.update_quota(project.id,
+            subnet=-1, network=-1, floatingip=-1, subnetpool=-1, port=-1,
+            security_group_rule=-1, security_group=-1, router=-1,
+            rbac_policy=-1)
+        self.keeper.client_factory.nova().native.quotas.update(project.id,
+            cores=-1, fixed_ips=-1, floating_ips=-1,
+            injected_file_content_bytes=-1, injected_file_path_bytes=-1,
+            injected_files=-1, instances=-1, key_pairs=-1, metadata_items=-1,
+            ram=-1, security_group_rules=-1, security_groups=-1,
+            server_group_members=-1, server_groups=-1)
 
-    @cache
+        return project
+
     def project_update(self):
         while True:
             name = self.faker.word()
@@ -263,12 +294,16 @@ class Keystone(object):
                 break
 
         while True:
+            # TO-DO: Make a normal warning logging
+            if len(self.cache["keystone"]["projects"]) == 1:
+                return
             project_id = self.keeper.get_random(
                 self.cache["keystone"]["projects"])
             project = self.keeper.get_by_id("keystone", "projects", project_id)
             if project.name != "admin":
                 break
-        return self.client.projects.update(project=project,
+
+        return self.native.projects.update(project=project,
                                            name=name,
                                            domain="default",
                                            description=("Project {}".
@@ -278,31 +313,208 @@ class Keystone(object):
     @uncache
     def project_delete(self):
         while True:
+            # TO-DO: Make a normal warning logging
+            if len(self.cache["keystone"]["projects"]) == 1:
+                return
             project_id = self.keeper.get_random(
                 self.cache["keystone"]["projects"])
             project = self.keeper.get_by_id("keystone", "projects", project_id)
             if project.name != "admin":
                 break
 
-        self.client.projects.delete(project)
+        self.native.projects.delete(project)
         return project_id
 
 
 class Neutron(object):
-    def __init__(self, cache):
-        pass
+    def __init__(self, cache, client, faker=None, keeper=None):
+        """Create `Neutron` class instance.
+
+        @param cache: Cache
+        @type cache: `cache.Cache`
+
+        @param client: An instance of the identity client
+        @type: client: `clientmanager.identity`
+
+        @param faker: An instance of the faker object
+        @type faker: `faker.Factory`
+
+        @param keeper: Reference to the keeper
+        @type keeper: `keeper.Keeper`
+        """
+
+        self.cache = cache
+        self.native = client
+        self.faker = faker
+        self.keeper = keeper
 
 
 class Cinder(object):
-    def __init__(self, cache):
-        pass
+    def __init__(self, cache, client, faker=None, keeper=None):
+        """Create `Cinder` class instance.
 
+        @param cache: Cache
+        @type cache: `cache.Cache`
 
-class Nova(object):
-    def __init__(self, cache):
-        pass
+        @param client: An instance of the identity client
+        @type: client: `clientmanager.identity`
+
+        @param faker: An instance of the faker object
+        @type faker: `faker.Factory`
+
+        @param keeper: Reference to the keeper
+        @type keeper: `keeper.Keeper`
+        """
+
+        self.cache = cache
+        self.native = client
+        self.faker = faker
+        self.keeper = keeper
+
+        self.volumes = lambda: None
+
+        self.volumes.get = self.native.volumes.get
+        self.volumes.find = self.native.volumes.find
+        self.volumes.list = self.native.volumes.list
+
+        self.volumes.create = self.volume_create
+        self.volumes.update = self.volume_update
+        self.volumes.extend = self.volume_extend
+        self.volumes.attach = self.volume_attach
+        self.volumes.detach = self.volume_detach
+        self.volumes.delete = self.volume_delete
+
+    @cache
+    def volume_create(self):
+        while True:
+            name = self.faker.word()
+            if self.keeper.get_by_name("cinder", "volumes", name) is None:
+                break
+        volume_sizes = [1, 2, 5, 10, 20, 40, 50]
+        volume = self.native.volumes.create(name=name,
+                                            size=random.choice(volume_sizes),
+                                            description=("Volume with name {}".
+                                                         format(name)))
+        self.native.volumes.reset_state(volume, "available", "detached")
+
+        return volume
+
+    def volume_update(self):
+        while True:
+            name = self.faker.name()
+            if self.keeper.get_by_name("cinder", "volumes", name) is None:
+                break
+
+        volume_id = self.keeper.get_random(self.cache["cinder"]["volumes"])
+
+        # TO-DO: Make a normal warning logging
+        if volume_id is None:
+            return
+
+        volume = self.keeper.get_by_id("cinder", "volumes", volume_id)
+
+        return self.native.volumes.update(volume=volume,
+                                          name=name,
+                                          description=("Volume with name {}".
+                                                       format(name)))
+
+    def volume_extend(self):
+        volume_id = self.keeper.get_random(self.cache["cinder"]["volumes"])
+
+        # TO-DO: Make a normal warning logging
+        if volume_id is None:
+            return
+
+        volume = self.keeper.get_by_id("cinder", "volumes", volume_id)
+        add_size = random.randint(1, 10)
+
+        return self.native.volumes.extend(volume=volume,
+                                          new_size=volume.size + add_size)
+
+    def volume_attach(self):
+        volume_id = self.keeper.get_unused(self.cache["cinder"]["volumes"])
+
+        # TO-DO: Make a normal warning logging
+        if volume_id is None:
+            return
+
+        self.cache["cinder"]["volumes"][volume_id] = True
+        volume = self.keeper.get_by_id("cinder", "volumes", volume_id)
+        instance_id = self.keeper.get_random(self.cache["nova"]["servers"])
+
+        # TO-DO: Make a normal warning logging
+        if instance_id is None:
+            return
+
+        return self.native.volumes.attach(volume, instance_id, volume.name)
+
+    def volume_detach(self):
+        volume_id = self.keeper.get_used(self.cache["cinder"]["volumes"])
+
+        # TO-DO: Make a normal warning logging
+        if volume_id is None:
+            return
+
+        self.cache["cinder"]["volumes"][volume_id] = False
+        volume = self.keeper.get_by_id("cinder", "volumes", volume_id)
+
+        return self.native.volumes.detach(volume)
+
+    @uncache
+    def volume_delete(self):
+        volume_id = self.keeper.get_random(self.cache["cinder"]["volumes"])
+
+        # TO-DO: Make a normal warning logging
+        if volume_id is None:
+            return
+
+        volume = self.keeper.get_by_id("cinder", "volumes", volume_id)
+        self.native.volumes.delete(volume)
+
+        return volume_id
 
 
 class Glance(object):
-    def __init__(self, cache):
-        pass
+    def __init__(self, cache, client, faker=None, keeper=None):
+        """Create `Glance` class instance.
+
+        @param cache: Cache
+        @type cache: `cache.Cache`
+
+        @param client: An instance of the identity client
+        @type: client: `clientmanager.identity`
+
+        @param faker: An instance of the faker object
+        @type faker: `faker.Factory`
+
+        @param keeper: Reference to the keeper
+        @type keeper: `keeper.Keeper`
+        """
+
+        self.cache = cache
+        self.native = client
+        self.faker = faker
+        self.keeper = keeper
+
+
+class Nova(object):
+    def __init__(self, cache, client, faker=None, keeper=None):
+        """Create `Nova` class instance.
+
+        @param cache: Cache
+        @type cache: `cache.Cache`
+
+        @param client: An instance of the identity client
+        @type: client: `clientmanager.identity`
+
+        @param faker: An instance of the faker object
+        @type faker: `faker.Factory`
+
+        @param keeper: Reference to the keeper
+        @type keeper: `keeper.Keeper`
+        """
+
+        self.cache = cache
+        self.native = client
+        self.faker = faker
+        self.keeper = keeper

--- a/spamostack/client_factory.py
+++ b/spamostack/client_factory.py
@@ -271,15 +271,15 @@ class Keystone(object):
                                                            format(name)),
                                               enabled=True)
         # quotas update
-        self.keeper.client_factory.cinder().native.quotas.update(project.id,
-            backup_gigabytes=-1, backups=-1, gigabytes=-1,
+        self.keeper.client_factory.cinder().native.quotas.update(
+            project.id, backup_gigabytes=-1, backups=-1, gigabytes=-1,
             per_volume_gigabytes=-1, snapshots=-1, volumes=-1)
-        self.keeper.client_factory.neutron().native.update_quota(project.id,
-            subnet=-1, network=-1, floatingip=-1, subnetpool=-1, port=-1,
-            security_group_rule=-1, security_group=-1, router=-1,
+        self.keeper.client_factory.neutron().native.update_quota(
+            project.id, subnet=-1, network=-1, floatingip=-1, subnetpool=-1,
+            port=-1, security_group_rule=-1, security_group=-1, router=-1,
             rbac_policy=-1)
-        self.keeper.client_factory.nova().native.quotas.update(project.id,
-            cores=-1, fixed_ips=-1, floating_ips=-1,
+        self.keeper.client_factory.nova().native.quotas.update(
+            project.id, cores=-1, fixed_ips=-1, floating_ips=-1,
             injected_file_content_bytes=-1, injected_file_path_bytes=-1,
             injected_files=-1, instances=-1, key_pairs=-1, metadata_items=-1,
             ram=-1, security_group_rules=-1, security_groups=-1,

--- a/spamostack/keeper.py
+++ b/spamostack/keeper.py
@@ -36,7 +36,23 @@ class Keeper(object):
 
         client = getattr(self.client_factory, "keystone")()
         user = client.users.find(name="admin")
+        project = client.projects.find(name="admin")
         self.cache["keystone"]["users"][user.id] = False
+
+        # quotas update
+        self.client_factory.cinder().native.quotas.update(project.id,
+            backup_gigabytes=-1, backups=-1, gigabytes=-1,
+            per_volume_gigabytes=-1, snapshots=-1, volumes=-1)
+        self.client_factory.neutron().native.update_quota(project.id,
+            subnet=-1, network=-1, floatingip=-1, subnetpool=-1, port=-1,
+            security_group_rule=-1, security_group=-1, router=-1,
+            rbac_policy=-1)
+        self.client_factory.nova().native.quotas.update(project.id,
+            cores=-1, fixed_ips=-1, floating_ips=-1,
+            injected_file_content_bytes=-1, injected_file_path_bytes=-1,
+            injected_files=-1, instances=-1, key_pairs=-1, metadata_items=-1,
+            ram=-1, security_group_rules=-1, security_groups=-1,
+            server_group_members=-1, server_groups=-1)
 
     def get_by_id(self, client_name, resource_name, id):
         """Get resource by id
@@ -93,7 +109,17 @@ class Keeper(object):
 
         for key, value in resource.iteritems():
             if value is False:
-                resource[key] = True
+                return key
+
+    def get_used(self, resource):
+        """Get used resource
+
+        @param resource: Part of the cache
+        @type resource: `str`
+        """
+
+        for key, value in resource.iteritems():
+            if value is True:
                 return key
 
     def get_random(self, resource):
@@ -118,7 +144,7 @@ class Keeper(object):
         for client_name in component_names:
             client = getattr(self.client_factory, client_name)()
             for resource_name, resource in self.cache[client_name].iteritems():
-                resource_obj = getattr(client.client, resource_name)
+                resource_obj = getattr(client.native, resource_name)
                 for id in resource.keys():
                     if id != admin_user_id:
                         resource_obj.delete(self.get_by_id(client_name,

--- a/spamostack/keeper.py
+++ b/spamostack/keeper.py
@@ -40,15 +40,15 @@ class Keeper(object):
         self.cache["keystone"]["users"][user.id] = False
 
         # quotas update
-        self.client_factory.cinder().native.quotas.update(project.id,
-            backup_gigabytes=-1, backups=-1, gigabytes=-1,
+        self.client_factory.cinder().native.quotas.update(
+            project.id, backup_gigabytes=-1, backups=-1, gigabytes=-1,
             per_volume_gigabytes=-1, snapshots=-1, volumes=-1)
-        self.client_factory.neutron().native.update_quota(project.id,
-            subnet=-1, network=-1, floatingip=-1, subnetpool=-1, port=-1,
-            security_group_rule=-1, security_group=-1, router=-1,
+        self.client_factory.neutron().native.update_quota(
+            project.id, subnet=-1, network=-1, floatingip=-1, subnetpool=-1,
+            port=-1, security_group_rule=-1, security_group=-1, router=-1,
             rbac_policy=-1)
-        self.client_factory.nova().native.quotas.update(project.id,
-            cores=-1, fixed_ips=-1, floating_ips=-1,
+        self.client_factory.nova().native.quotas.update(
+            project.id, cores=-1, fixed_ips=-1, floating_ips=-1,
             injected_file_content_bytes=-1, injected_file_path_bytes=-1,
             injected_files=-1, instances=-1, key_pairs=-1, metadata_items=-1,
             ram=-1, security_group_rules=-1, security_groups=-1,


### PR DESCRIPTION
- keeper.py
  - Change the behaviour of `get_unused` method
  - Add `get_used` method
  - Update quotas of `admin` project in the `default_init`
- client_factory.py
  - Add `Cinder` client class
  - Add processing of pipeline misconfigurations
  - Update quotas in the every new projects
  - Field `client` of the created clients now accessed with 'native'
